### PR TITLE
Use released version of creusot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,9 @@ dependencies = [
 
 [[package]]
 name = "creusot-contracts"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81f64a6f9a3e29a676f35267e5108ee07299c32fb04ea3be9d50ff1fe07bcb"
 dependencies = [
  "creusot-contracts-dummy",
  "creusot-contracts-proc",
@@ -62,14 +64,18 @@ dependencies = [
 
 [[package]]
 name = "creusot-contracts-dummy"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e589fd3e9846f65ae3c18f5b6c51eafa9fe6bafe473fc5894e067333c7affed8"
 dependencies = [
  "quote",
 ]
 
 [[package]]
 name = "creusot-contracts-proc"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1b6addccf1f6f9dc6f5c31280ca8f40535ee31976a85103373b4ad16f8a0b0"
 dependencies = [
  "pearlite-syn",
  "proc-macro2",
@@ -250,7 +256,9 @@ dependencies = [
 
 [[package]]
 name = "pearlite-syn"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3083dfa80aedb67b392087bd8027a9bb5435eb4f3703d02ca6a11e1c81209"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-creusot-contracts = { path = "/home/ruth/creusot/creusot-contracts" }
+creusot-contracts = { version =  "0.1.1" }
 textplots = "0.8.6"
 rustyline = "14.0.0"

--- a/README.md
+++ b/README.md
@@ -28,28 +28,13 @@ We have verified the following properties for each DBM operation:
 
 ## Getting Started
 
-To use this repository, you will need to have [Creusot](https://github.com/creusot-rs/creusot) installed on your machine. If you haven't installed it yet, refer to the [README.md](https://github.com/creusot-rs/creusot?tab=readme-ov-file#installing-creusot-as-a-user) in the official repository.
+To use this repository, you will need to have [Creusot](https://github.com/creusot-rs/creusot) installed on your machine. If you haven't installed it yet, refer to the [README.md](https://github.com/creusot-rs/creusot?tab=readme-ov-file#installing-creusot-as-a-user) in the official repository. Make sure to install version `0.1.1` of Creusot, either by installing from source ref `v0.1.1` or by downloading the source from the release page. 
 
 Next, clone this repository and then move into to the dbm-creusot directory:
 
 ```
 $ git clone https://github.com/ruth561/VerifiedDBM.git
 $ cd dbm-creusot
-```
-
-Copy the rust-toolchain file from the Creusot repository to this repository:
-
-```
-$ cp /path/to/creusot/rust-toolchain ./
-```
-
-To link this repository with Creusot, replace the following dependency in `Cargo.toml`:
-
-```toml
-[...]
-[dependencies]
-creusot-contracts = { path = "/path/to/creusot/creusot-contracts" }
-[...]
 ```
 
 Now, all necessary procedures are completed! To perform proofs for each DBM operation, please execute the following command:


### PR DESCRIPTION
This PR just updates the dependency on `creusot-contracts` to use the released version on `crates.io` rather than the source install, making it more easily installable. 

I checked the proofs locally as well. 

